### PR TITLE
 provider fallback in Envoy AI Gateway

### DIFF
--- a/.github/workflows/demo-03-provider-fallback.yml
+++ b/.github/workflows/demo-03-provider-fallback.yml
@@ -1,0 +1,187 @@
+name: Demo 03 - Provider Fallback
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'demos/03-provider-fallback/**'
+      - '.github/workflows/demo-03-provider-fallback.yml'
+  pull_request:
+    branches: [ main ]
+    paths:
+      - 'demos/03-provider-fallback/**'
+      - '.github/workflows/demo-03-provider-fallback.yml'
+  workflow_dispatch:
+
+jobs:
+  demo-test:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: ./demos/03-provider-fallback
+    
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v4
+
+    - name: Install Task
+      uses: arduino/setup-task@v2
+      with:
+        version: 3.x
+        repo-token: ${{ secrets.GITHUB_TOKEN }}
+        
+    - name: Setup prerequisites
+      run: |
+        # Install kubectl
+        curl -LO "https://dl.k8s.io/release/$(curl -L -s https://dl.k8s.io/release/stable.txt)/bin/linux/amd64/kubectl"
+        chmod +x kubectl
+        sudo mv kubectl /usr/local/bin/
+        
+        # Install kind
+        curl -Lo ./kind https://kind.sigs.k8s.io/dl/v0.29.0/kind-linux-amd64
+        chmod +x ./kind
+        sudo mv ./kind /usr/local/bin/
+        
+        # Install helm
+        curl https://raw.githubusercontent.com/helm/helm/main/scripts/get-helm-3 | bash
+        
+        # Install jq (should already be available)
+        sudo apt-get update
+        sudo apt-get install -y jq bc
+        
+        # Verify installations
+        echo "Tool versions:"
+        kubectl version --client
+        kind version
+        helm version
+        jq --version
+        bc --version
+        docker --version
+        task --version
+
+    - name: Free up disk space
+      run: |
+        docker system prune -af
+        
+    - name: Clean up existing Kind resources
+      run: |
+        echo "🧹 Cleaning up any existing Kind clusters and containers..."
+        # Delete any existing kind clusters
+        kind delete clusters --all || true
+
+    - name: Deploy demo components
+      run: |
+        echo "🚀 Setting up provider fallback demo..."
+        task setup
+
+    - name: Start port forwarding in background
+      run: |
+        echo "🔌 Starting port forwarding..."
+        task port-forward
+
+    - name: Test normal operation
+      run: |
+        echo "🧪 Testing normal operation with healthy primary..."
+        sleep 5  # Wait for port forwarding to stabilize
+        task test-normal
+
+    - name: Test rate limit fallback
+      run: |
+        echo "🧪 Testing rate limit errors trigger fallback..."
+        task test-rate-limit-fallback
+
+    - name: Test auth failure fallback
+      run: |
+        echo "🧪 Testing authentication errors trigger fallback..."
+        task test-auth-failure-fallback
+
+    - name: Test context length fallback
+      run: |
+        echo "🧪 Testing context length errors trigger fallback..."
+        task test-context-length-fallback
+
+    - name: Test server error fallback
+      run: |
+        echo "🧪 Testing server errors trigger fallback..."
+        task test-server-error-fallback
+
+    - name: Test model not found fallback
+      run: |
+        echo "🧪 Testing model not found errors trigger fallback..."
+        task test-model-not-found-fallback
+
+    - name: Test mixed failures fallback
+      run: |
+        echo "🧪 Testing mixed failure types trigger fallback..."
+        task test-mixed-failures-fallback
+
+    - name: Test timeout scenario
+      run: |
+        echo "🧪 Testing timeout and fallback behavior..."
+        task test-timeout
+
+    - name: Test bulk failures
+      run: |
+        echo "🧪 Testing bulk requests with intermittent failures..."
+        task test-bulk-failures
+
+    - name: Test circuit breaker
+      run: |
+        echo "🧪 Testing circuit breaker activation..."
+        task test-circuit-breaker
+
+    - name: Check primary provider health
+      run: |
+        echo "📊 Checking primary provider health..."
+        task test-primary-health || true
+
+    - name: Capture metrics
+      run: |
+        echo "📊 Capturing provider fallback metrics..."
+        task metrics || true
+
+    - name: Check component status
+      run: |
+        echo "📋 Checking component status..."
+        task status
+
+    - name: Show component logs
+      if: always()
+      run: |
+        echo "📋 Showing component logs..."
+        task logs || true
+
+    - name: Show failure diagnostics
+      if: failure()
+      run: |
+        echo "🔍 Failure diagnostics..."
+        echo "=== Pods Status ==="
+        kubectl get pods --all-namespaces || true
+        echo "=== BackendTrafficPolicy Status ==="
+        kubectl get backendtrafficpolicy --all-namespaces || true
+        echo "=== AIGatewayRoute Status ==="
+        kubectl get aigatewayroute --all-namespaces || true
+        echo "=== Gateway Status ==="
+        kubectl get gateways --all-namespaces || true
+        echo "=== Events ==="
+        kubectl get events --all-namespaces --sort-by='.lastTimestamp' || true
+        echo "=== Envoy Gateway Logs ==="
+        kubectl logs -n envoy-gateway-system -l control-plane=envoy-gateway --tail=50 || true
+        echo "=== Primary Provider Logs ==="
+        kubectl logs -l app=llm-primary --tail=50 || true
+        echo "=== Fallback Provider Logs ==="
+        kubectl logs -l app=llm-fallback --tail=50 || true
+        echo "=== Gateway Proxy Logs ==="
+        kubectl logs -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-name=envoy-ai-gateway --tail=50 || true
+
+    - name: Cleanup
+      if: always()
+      run: |
+        echo "🧹 Cleanup..."
+        task cleanup || true
+        cd ../../
+        task cleanup || true
+        # Kill any remaining port forwarding processes
+        pkill -f "kubectl port-forward" || true
+        # Clean up kind cluster
+        kind delete clusters --all || true

--- a/.github/workflows/demo-03-provider-fallback.yml
+++ b/.github/workflows/demo-03-provider-fallback.yml
@@ -120,11 +120,6 @@ jobs:
         echo "🧪 Testing timeout and fallback behavior..."
         task test-timeout
 
-    - name: Test bulk failures
-      run: |
-        echo "🧪 Testing bulk requests with intermittent failures..."
-        task test-bulk-failures
-
     - name: Test circuit breaker
       run: |
         echo "🧪 Testing circuit breaker activation..."

--- a/demos/03-provider-fallback/README.md
+++ b/demos/03-provider-fallback/README.md
@@ -1,0 +1,290 @@
+# Provider Fallback with Envoy AI Gateway
+
+This demo showcases automatic provider fallback capabilities, demonstrating how the Envoy AI Gateway handles failures from primary AI providers by seamlessly switching to backup providers without disrupting service.
+
+## Overview
+
+This demo sets up:
+- **Primary AI Provider** (simulating an unreliable service with intermittent failures)
+- **Fallback AI Provider** (stable backup service)
+- **Automatic failover** when the primary provider returns errors or times out
+- **Smart retry policies** with exponential backoff
+- **Health-based routing** to avoid unhealthy backends
+
+## Prerequisites
+
+- `kubectl` configured to access your cluster
+- `task` (Taskfile) installed ([installation guide](https://taskfile.dev/installation/))
+- `jq` for JSON pretty-printing (optional but recommended)
+
+## Quick Start
+
+1. Navigate to the demo directory:
+```bash
+cd demos/03-provider-fallback
+```
+
+2. Run the complete setup:
+```bash
+task setup
+```
+
+This will:
+- Deploy primary and fallback LLM backends
+- Configure automatic failover policies
+- Set up retry and circuit breaker configurations
+
+3. In a separate terminal, start port forwarding:
+```bash
+task port-forward
+```
+
+4. Test the fallback behavior:
+```bash
+task test
+```
+
+> **Next Steps**: Once you've completed the setup and testing, check out the [Envoy AI Gateway Provider Fallback Guide](https://aigateway.envoyproxy.io/docs/capabilities/traffic/provider-fallback) to learn more about advanced fallback configurations.
+
+## Available Tasks
+
+Run `task` to see all available tasks:
+
+- `task setup` - Complete setup of the demo environment
+- `task deploy` - Deploy all components (primary, fallback, and gateway config)
+- `task port-forward` - Start port forwarding to access the gateway
+- `task test` - Run all test scenarios
+- `task test-normal` - Test successful requests through primary provider
+- `task test-primary-failure` - Test failover when primary fails
+- `task test-bulk-failures` - Send multiple requests to observe fallback behavior
+- `task simulate-primary-failure` - Make primary backend return errors
+- `task simulate-primary-recovery` - Restore primary backend to healthy state
+- `task simulate-primary-slowness` - Make primary backend slow (timeout scenario)
+- `task logs` - Show logs from all components
+- `task metrics` - Show fallback and retry metrics
+- `task status` - Check status of all components
+- `task cleanup` - Remove all demo resources
+
+## Architecture
+
+```
+┌─────────────┐     ┌─────────────────┐     ┌──────────────────────┐
+│   Client    │────▶│  Envoy AI       │────▶│  Primary Provider   │
+│             │     │  Gateway        │     │  (llm-primary)      │
+└─────────────┘     └─────────────────┘     └──────────────────────┘
+                           │                            ❌ (on failure)
+                           │                            │
+                           ▼                            ▼
+                    ┌─────────────────┐     ┌──────────────────────┐
+                    │  Retry & Route  │────▶│  Fallback Provider  │
+                    │  Selection      │     │  (llm-fallback)     │
+                    └─────────────────┘     └──────────────────────┘
+```
+
+## Configuration Details
+
+### Primary Provider (Unreliable)
+- **Name**: `llm-primary`
+- **Model**: `gpt-4`
+- **Behavior**: Simulated with variable latency and random responses
+- **Port**: 8000
+- **Mode**: Random (returns varied responses)
+- **Latency**: 500ms ± 200ms first token, 50ms ± 20ms inter-token
+
+### Fallback Provider (Stable)
+- **Name**: `llm-fallback`
+- **Model**: `gpt-4` (same model, different provider)
+- **Port**: 8001
+- **Mode**: Echo (returns input for reliability)
+- **Latency**: 100ms first token, 20ms inter-token
+- **Purpose**: Stable backup when primary fails
+
+### Retry Policy
+- **Max Retries**: 3 attempts
+- **Backoff**: Exponential (1s base, 10s max)
+- **Retry On**: 5xx errors, reset, connect-failure
+- **Per-Try Timeout**: 10 seconds
+
+### Circuit Breaker
+- **Consecutive Errors**: 5 failures trigger circuit open
+- **Recovery**: 30-second interval checks
+- **Ejection Duration**: 30 seconds
+
+## Testing Scenarios
+
+### Scenario 1: Normal Operation
+```bash
+task test-normal
+```
+Sends requests when primary is healthy. All requests should be handled by the primary provider.
+
+### Scenario 2: Primary Provider Failure
+```bash
+# First, simulate primary failure
+task simulate-primary-failure
+
+# Then test the requests
+task test-primary-failure
+```
+Requests automatically failover to the fallback provider after primary returns errors.
+
+### Scenario 3: Primary Provider Timeout
+```bash
+# Simulate slow responses
+task simulate-primary-slowness
+
+# Test timeout and fallback
+task test-timeout
+```
+When primary is slow, requests timeout and retry with fallback provider.
+
+### Scenario 4: Circuit Breaker Activation
+```bash
+# Send many requests to trigger circuit breaker
+task test-circuit-breaker
+```
+After consecutive failures, circuit breaker opens and all traffic goes directly to fallback.
+
+## Monitoring Fallback Behavior
+
+### View Real-time Metrics
+```bash
+task metrics
+```
+
+This shows:
+- Retry attempts and success rates
+- Circuit breaker state (open/closed)
+- Request distribution between primary and fallback
+- Error rates per backend
+
+### Example Metrics Output
+```
+=== Upstream Metrics ===
+Primary Provider (llm-primary):
+  Total Requests: 100
+  Success Rate: 20%
+  Circuit Breaker: OPEN
+  
+Fallback Provider (llm-fallback):
+  Total Requests: 80
+  Success Rate: 100%
+  Circuit Breaker: CLOSED
+
+=== Retry Metrics ===
+Total Retries: 80
+Successful After Retry: 80
+Failed After All Retries: 0
+```
+
+### View Logs
+```bash
+# All components
+task logs
+
+# Just primary provider
+task logs-primary
+
+# Just fallback provider
+task logs-fallback
+
+# Gateway logs with retry/fallback events
+task logs-gateway
+```
+
+## How It Works
+
+1. **Initial Request**: Client sends request to Envoy AI Gateway
+
+2. **Primary Attempt**: Gateway routes to primary provider first
+
+3. **Failure Detection**: If primary returns error or times out:
+   - Gateway marks the attempt as failed
+   - Updates circuit breaker statistics
+
+4. **Automatic Retry**: Based on retry policy:
+   - Waits with exponential backoff
+   - Routes to next available backend (fallback)
+
+5. **Circuit Breaker**: After consecutive failures:
+   - Opens circuit to primary provider
+   - All traffic goes directly to fallback
+   - Periodically checks if primary recovered
+
+6. **Response**: Client receives response from whichever provider succeeded
+
+## Advanced Configuration
+
+### Custom Failure Conditions
+
+You can define what constitutes a failure:
+```yaml
+retryOn:
+  - 5xx           # Any 500-level error
+  - reset         # Connection reset
+  - connect-failure
+  - retriable-4xx # Specific 4xx errors
+```
+
+### Weighted Routing
+
+Configure traffic distribution when both providers are healthy:
+```yaml
+backendRefs:
+  - name: primary-backend
+    weight: 80    # 80% of traffic
+  - name: fallback-backend
+    weight: 20    # 20% of traffic
+```
+
+### Health Checking
+
+Configure active health checks:
+```yaml
+healthCheck:
+  interval: 10s
+  timeout: 3s
+  unhealthyThreshold: 3
+  healthyThreshold: 2
+  path: /v1/models
+```
+
+## Troubleshooting
+
+### Fallback Not Working
+1. Check both providers are running: `task status`
+2. Verify retry policy is applied: `kubectl get backendtrafficpolicy`
+3. Check gateway logs for retry attempts: `task logs-gateway`
+
+### All Requests Going to Fallback
+1. Check primary provider health: `task test-primary-health`
+2. Circuit breaker may be open: `task metrics`
+3. Reset primary to healthy: `task simulate-primary-recovery`
+
+### Slow Response Times
+1. Check if retries are happening: `task metrics`
+2. Reduce per-try timeout if needed
+3. Consider adjusting backoff parameters
+
+## Cleanup
+
+To remove all demo resources:
+```bash
+task cleanup
+```
+
+## Next Steps
+
+After exploring this demo, you can:
+1. Configure multiple fallback providers in priority order
+2. Implement geographic-based fallback
+3. Add custom health checks for providers
+4. Configure different retry policies per model
+5. Integrate with monitoring systems for alerts
+
+## References
+
+- [Provider Fallback Documentation](https://aigateway.envoyproxy.io/docs/capabilities/traffic/provider-fallback)
+- [Envoy Retry Policy](https://www.envoyproxy.io/docs/envoy/latest/configuration/http/http_filters/router_filter#config-http-filters-router-x-envoy-retry-on)
+- [Circuit Breaker Pattern](https://www.envoyproxy.io/docs/envoy/latest/intro/arch_overview/upstream/circuit_breaking)
+- [BackendTrafficPolicy API](https://gateway.envoyproxy.io/docs/api/extension_types/#backendtrafficpolicy)

--- a/demos/03-provider-fallback/Taskfile.yml
+++ b/demos/03-provider-fallback/Taskfile.yml
@@ -5,7 +5,7 @@ vars:
   GATEWAY_NAME: envoy-ai-gateway
   PRIMARY_BACKEND: llm-primary
   FALLBACK_BACKEND: llm-fallback
-  MODEL: qwen3
+  MODEL: gpt-4
   PORT_FORWARD: 8080
 
 tasks:
@@ -70,6 +70,180 @@ tasks:
     cmds:
       - echo "All tests completed!"
 
+  test-all-failure-modes:
+    desc: "Test all failure modes with fallback"
+    cmds:
+      - task: test-rate-limit-fallback
+      - task: test-auth-failure-fallback
+      - task: test-context-length-fallback
+      - task: test-server-error-fallback
+      - task: test-model-not-found-fallback
+      - task: test-mixed-failures-fallback
+      - task: simulate-primary-recovery
+      - echo "All failure mode tests completed!"
+
+  test-rate-limit-fallback:
+    desc: "Test rate limit errors trigger fallback"
+    cmds:
+      - task: simulate-rate-limit-failure
+      - |
+        echo "=== Testing rate limit fallback (HTTP 429 → fallback) ==="
+        for i in {1..3}; do
+          echo -e "\nRequest $i:"
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Test rate limit fallback"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions)
+          
+          HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+          
+          echo "Final Status: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "✅ Fallback successful!"
+            echo "$BODY" | jq -r '.choices[0].message.content // .' 2>/dev/null || echo "$BODY"
+          else
+            echo "❌ Request failed with status $HTTP_STATUS"
+          fi
+        done
+
+  test-auth-failure-fallback:
+    desc: "Test auth errors trigger fallback"
+    cmds:
+      - task: simulate-auth-failure
+      - |
+        echo "=== Testing auth failure fallback (HTTP 401 → fallback) ==="
+        for i in {1..3}; do
+          echo -e "\nRequest $i:"
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Test auth failure fallback"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions)
+          
+          HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+          
+          echo "Final Status: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "✅ Fallback successful!"
+            echo "$BODY" | jq -r '.choices[0].message.content // .' 2>/dev/null || echo "$BODY"
+          else
+            echo "❌ Request failed with status $HTTP_STATUS"
+          fi
+        done
+
+  test-context-length-fallback:
+    desc: "Test context length errors trigger fallback"
+    cmds:
+      - task: simulate-context-length-failure
+      - |
+        echo "=== Testing context length fallback (HTTP 400 → fallback) ==="
+        for i in {1..3}; do
+          echo -e "\nRequest $i:"
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Test context length fallback"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions)
+          
+          HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+          
+          echo "Final Status: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "✅ Fallback successful!"
+            echo "$BODY" | jq -r '.choices[0].message.content // .' 2>/dev/null || echo "$BODY"
+          else
+            echo "❌ Request failed with status $HTTP_STATUS"
+          fi
+        done
+
+  test-server-error-fallback:
+    desc: "Test server errors trigger fallback"
+    cmds:
+      - task: simulate-server-error-failure
+      - |
+        echo "=== Testing server error fallback (HTTP 503 → fallback) ==="
+        for i in {1..3}; do
+          echo -e "\nRequest $i:"
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Test server error fallback"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions)
+          
+          HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+          
+          echo "Final Status: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "✅ Fallback successful!"
+            echo "$BODY" | jq -r '.choices[0].message.content // .' 2>/dev/null || echo "$BODY"
+          else
+            echo "❌ Request failed with status $HTTP_STATUS"
+          fi
+        done
+
+  test-model-not-found-fallback:
+    desc: "Test model not found errors trigger fallback"
+    cmds:
+      - task: simulate-model-not-found-failure
+      - |
+        echo "=== Testing model not found fallback (HTTP 404 → fallback) ==="
+        for i in {1..3}; do
+          echo -e "\nRequest $i:"
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Test model not found fallback"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions)
+          
+          HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+          
+          echo "Final Status: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "✅ Fallback successful!"
+            echo "$BODY" | jq -r '.choices[0].message.content // .' 2>/dev/null || echo "$BODY"
+          else
+            echo "❌ Request failed with status $HTTP_STATUS"
+          fi
+        done
+
+  test-mixed-failures-fallback:
+    desc: "Test mixed failure types trigger fallback"
+    cmds:
+      - task: simulate-mixed-failures
+      - |
+        echo "=== Testing mixed failures fallback (multiple error types → fallback) ==="
+        for i in {1..5}; do
+          echo -e "\nRequest $i:"
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Test mixed failures fallback"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions)
+          
+          HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+          
+          echo "Final Status: $HTTP_STATUS"
+          if [ "$HTTP_STATUS" = "200" ]; then
+            echo "✅ Fallback successful!"
+            echo "$BODY" | jq -r '.choices[0].message.content // .' 2>/dev/null || echo "$BODY"
+          else
+            echo "❌ Request failed with status $HTTP_STATUS"
+          fi
+        done
+
   test-normal:
     desc: "Test normal operation with healthy primary"
     cmds:
@@ -105,8 +279,35 @@ tasks:
           
           echo "Status: $HTTP_STATUS"
           echo "$BODY" | jq -r '.choices[0].message.content // .error // .' 2>/dev/null || echo "$BODY"
+          
+          # Check which backend served the request
+          echo "Checking which backend served this request..."
+          FALLBACK_LOGS=$(kubectl logs -l app={{.FALLBACK_BACKEND}} -n {{.NAMESPACE}} --tail=5 2>/dev/null | grep -E "(POST|GET|chat|completions)" | tail -1)
+          PRIMARY_LOGS=$(kubectl logs -l app={{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} --tail=5 2>/dev/null | grep -E "(POST|GET|chat|completions)" | tail -1)
+          
+          if [[ -n "$FALLBACK_LOGS" ]]; then
+            echo "✅ CONFIRMED: Request served by FALLBACK backend"
+          elif [[ -n "$PRIMARY_LOGS" ]]; then
+            echo "⚠️  Request served by primary backend (fallback may not have activated)"
+          else
+            echo "❓ Unable to determine which backend served the request"
+          fi
         done
-      - task: simulate-primary-recovery
+      - |
+        echo -e "\n=== Recovery Options ==="
+        echo "Primary backend is currently configured to fail."
+        echo "Options:"
+        echo "1. Keep primary failed for further testing"
+        echo "2. Recover primary to healthy state"
+        echo ""
+        read -p "Do you want to recover the primary backend now? (y/N): " RECOVER
+        if [[ "$RECOVER" == "y" || "$RECOVER" == "Y" ]]; then
+          echo "Recovering primary backend..."
+          task simulate-primary-recovery
+        else
+          echo "Primary backend remains in failed state."
+          echo "Use 'task simulate-primary-recovery' to recover it later."
+        fi
 
   test-bulk-failures:
     desc: "Send multiple requests to observe fallback behavior"
@@ -191,30 +392,103 @@ tasks:
         echo "=== Checking primary provider health ==="
         kubectl exec -n {{.NAMESPACE}} deploy/{{.PRIMARY_BACKEND}} -- curl -s localhost:8000/v1/models | jq . || echo "Primary provider unhealthy"
 
-  simulate-primary-failure:
-    desc: "Make primary backend return errors"
+  # Failure mode simulation tasks using LLM-D Inference Simulator capabilities
+  simulate-rate-limit-failure:
+    desc: "Simulate rate limit errors (HTTP 429)"
     cmds:
       - |
-        echo "Configuring primary backend to fail..."
-        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} FAILURE_RATE=100
+        echo "Configuring primary backend to return rate limit errors..."
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
+          LLM_D_MODE=failure \
+          LLM_D_FAILURE_INJECTION_RATE=80 \
+          LLM_D_FAILURE_TYPES=rate_limit
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
-        echo "Primary backend now returning errors"
+        echo "Primary backend now returning 80% rate limit errors (HTTP 429)"
+
+  simulate-auth-failure:
+    desc: "Simulate authentication errors (HTTP 401)"
+    cmds:
+      - |
+        echo "Configuring primary backend to return auth errors..."
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
+          LLM_D_MODE=failure \
+          LLM_D_FAILURE_INJECTION_RATE=70 \
+          LLM_D_FAILURE_TYPES=invalid_api_key
+        kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
+        echo "Primary backend now returning 70% auth errors (HTTP 401)"
+
+  simulate-context-length-failure:
+    desc: "Simulate context length exceeded errors (HTTP 400)"
+    cmds:
+      - |
+        echo "Configuring primary backend to return context length errors..."
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
+          LLM_D_MODE=failure \
+          LLM_D_FAILURE_INJECTION_RATE=60 \
+          LLM_D_FAILURE_TYPES=context_length
+        kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
+        echo "Primary backend now returning 60% context length errors (HTTP 400)"
+
+  simulate-server-error-failure:
+    desc: "Simulate server errors (HTTP 503)"
+    cmds:
+      - |
+        echo "Configuring primary backend to return server errors..."
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
+          LLM_D_MODE=failure \
+          LLM_D_FAILURE_INJECTION_RATE=90 \
+          LLM_D_FAILURE_TYPES=server_error
+        kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
+        echo "Primary backend now returning 90% server errors (HTTP 503)"
+
+  simulate-model-not-found-failure:
+    desc: "Simulate model not found errors (HTTP 404)"
+    cmds:
+      - |
+        echo "Configuring primary backend to return model not found errors..."
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
+          LLM_D_MODE=failure \
+          LLM_D_FAILURE_INJECTION_RATE=50 \
+          LLM_D_FAILURE_TYPES=model_not_found
+        kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
+        echo "Primary backend now returning 50% model not found errors (HTTP 404)"
+
+  simulate-mixed-failures:
+    desc: "Simulate multiple failure types simultaneously"
+    cmds:
+      - |
+        echo "Configuring primary backend with mixed failures..."
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
+          LLM_D_MODE=failure \
+          LLM_D_FAILURE_INJECTION_RATE=75 \
+          LLM_D_FAILURE_TYPES=rate_limit,server_error,context_length
+        kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
+        echo "Primary backend now returning 75% mixed failures (rate_limit, server_error, context_length)"
+
+  simulate-primary-failure:
+    desc: "Legacy: Make primary backend return generic errors"
+    cmds:
+      - task: simulate-server-error-failure
 
   simulate-primary-recovery:
     desc: "Restore primary backend to healthy state"
     cmds:
       - |
         echo "Restoring primary backend to healthy state..."
-        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} FAILURE_RATE=20
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
+          LLM_D_MODE=echo \
+          LLM_D_FAILURE_INJECTION_RATE- \
+          LLM_D_FAILURE_TYPES-
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
-        echo "Primary backend restored (80% success rate)"
+        echo "Primary backend restored to healthy echo mode"
 
   simulate-primary-slowness:
     desc: "Make primary backend slow (timeout scenario)"
     cmds:
       - |
         echo "Configuring primary backend to be slow..."
-        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} RESPONSE_DELAY=15
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
+          LLM_D_RESPONSE_DELAY=15000
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now slow (15s delay)"
 
@@ -229,13 +503,13 @@ tasks:
     desc: "Show logs from primary provider"
     cmds:
       - echo "=== Primary Provider Logs ==="
-      - kubectl logs -l app={{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} --tail=10
+      - kubectl logs -l app={{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} --tail=20 | jq -c .
 
   logs-fallback:
     desc: "Show logs from fallback provider"
     cmds:
       - echo "=== Fallback Provider Logs ==="
-      - kubectl logs -l app={{.FALLBACK_BACKEND}} -n {{.NAMESPACE}} --tail=10
+      - kubectl logs -l app={{.FALLBACK_BACKEND}} -n {{.NAMESPACE}} --tail=20 | jq -c .
 
   logs-gateway:
     desc: "Show gateway logs with retry/fallback events"
@@ -243,7 +517,7 @@ tasks:
       - |
         echo "=== Gateway Logs (retry/fallback events) ==="
         ENVOY_POD=$(kubectl get pods -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-name={{.GATEWAY_NAME}} -o jsonpath='{.items[0].metadata.name}')
-        kubectl logs -n envoy-gateway-system $ENVOY_POD --tail=20 | grep -E "(retry|fallback|circuit|timeout)" || echo "No retry/fallback events in recent logs"
+        kubectl logs -n envoy-gateway-system $ENVOY_POD --tail=20 | jq -c .
 
   metrics:
     desc: "Show fallback and retry metrics"

--- a/demos/03-provider-fallback/Taskfile.yml
+++ b/demos/03-provider-fallback/Taskfile.yml
@@ -1,0 +1,347 @@
+version: '3'
+
+vars:
+  NAMESPACE: default
+  GATEWAY_NAME: envoy-ai-gateway
+  PRIMARY_BACKEND: llm-primary
+  FALLBACK_BACKEND: llm-fallback
+  MODEL: gpt-4
+  PORT_FORWARD: 8080
+
+tasks:
+  default:
+    desc: "Show available tasks"
+    cmds:
+      - task --list --sort=none
+
+  prerequisites:
+    desc: "Ensure base environment is ready"
+    dir: ../01-getting-started
+    cmds:
+      - task prerequisites
+
+  setup:
+    desc: "Complete setup of the provider fallback demo"
+    cmds:
+      - task: prerequisites
+      - task: deploy
+      - task: wait-ready
+      - echo "Provider fallback setup complete!"
+      - echo "Run 'task test' to test the fallback behavior"
+    generates:
+      - .task/setup.done
+    status:
+      - test -f .task/setup.done
+
+  deploy:
+    desc: "Deploy primary and fallback providers with gateway configuration"
+    cmds:
+      - kubectl apply -f primary-backend.yaml
+      - kubectl apply -f fallback-backend.yaml
+      - kubectl apply -f aigatewayroute-with-fallback.yaml
+      - kubectl apply -f retry-policy.yaml
+      - echo "Deployment initiated..."
+
+  wait-ready:
+    desc: "Wait for all components to be ready"
+    cmds:
+      - echo "Waiting for Primary Provider to be ready..."
+      - kubectl wait --for=condition=ready pod -l app={{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} --timeout=300s
+      - echo "Waiting for Fallback Provider to be ready..."
+      - kubectl wait --for=condition=ready pod -l app={{.FALLBACK_BACKEND}} -n {{.NAMESPACE}} --timeout=300s
+      - echo "All providers are ready!"
+      - sleep 5
+
+  port-forward:
+    desc: "Start port forwarding to gateway"
+    cmds:
+      - |
+        # Check if port-forward is already running
+        if [ -f .task/port-forward.pid ]; then
+          PID=$(cat .task/port-forward.pid)
+          if kill -0 $PID 2>/dev/null; then
+            echo "Port forwarding already running on PID $PID"
+            exit 0
+          fi
+        fi
+        
+        # Start port forwarding in background
+        mkdir -p .task
+        ENVOY_SERVICE=$(kubectl get svc -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-name={{.GATEWAY_NAME}} -o jsonpath='{.items[0].metadata.name}')
+        echo "Starting port forwarding to service: $ENVOY_SERVICE on port {{.PORT_FORWARD}}"
+        nohup kubectl port-forward -n envoy-gateway-system svc/$ENVOY_SERVICE {{.PORT_FORWARD}}:80 > .task/port-forward.log 2>&1 &
+        echo $! > .task/port-forward.pid
+        
+        # Wait for port forwarding to be ready
+        echo "Waiting for port forwarding to be ready..."
+        sleep 3
+        echo "✅ Port forwarding started in background (PID: $(cat .task/port-forward.pid))"
+        echo "Use 'task stop-port-forward' to stop"
+    generates:
+      - .task/port-forward.pid
+    status:
+      - test -f .task/port-forward.pid
+      - kill -0 $(cat .task/port-forward.pid 2>/dev/null) 2>/dev/null
+
+  stop-port-forward:
+    desc: "Stop background port forwarding"
+    cmds:
+      - |
+        if [ -f .task/port-forward.pid ]; then
+          PID=$(cat .task/port-forward.pid)
+          if kill -0 $PID 2>/dev/null; then
+            echo "Stopping port forwarding (PID: $PID)"
+            kill $PID
+            sleep 2
+            kill -9 $PID 2>/dev/null || true
+            echo "✅ Port forwarding stopped"
+          else
+            echo "Port forwarding process not running"
+          fi
+          rm -f .task/port-forward.pid .task/port-forward.log
+        else
+          echo "No port forwarding process found"
+        fi
+        pkill -f "kubectl.*port-forward.*{{.PORT_FORWARD}}" || true
+
+  test:
+    desc: "Run all test scenarios"
+    deps: [test-normal, test-primary-failure, test-bulk-failures]
+    cmds:
+      - echo "All tests completed!"
+
+  test-normal:
+    desc: "Test normal operation with healthy primary"
+    cmds:
+      - |
+        echo "=== Testing normal operation (primary should handle requests) ==="
+        for i in {1..3}; do
+          echo -e "\nRequest $i:"
+          curl -s -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Test normal operation"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions | jq -r '.choices[0].message.content // .error // .'
+        done
+
+  test-primary-failure:
+    desc: "Test failover when primary fails"
+    cmds:
+      - task: simulate-primary-failure
+      - |
+        echo "=== Testing with primary failure (should failover to fallback) ==="
+        for i in {1..3}; do
+          echo -e "\nRequest $i:"
+          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Test with primary failure"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions)
+          
+          HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
+          
+          echo "Status: $HTTP_STATUS"
+          echo "$BODY" | jq -r '.choices[0].message.content // .error // .' 2>/dev/null || echo "$BODY"
+        done
+      - task: simulate-primary-recovery
+
+  test-bulk-failures:
+    desc: "Send multiple requests to observe fallback behavior"
+    cmds:
+      - |
+        echo "=== Testing bulk requests with intermittent failures ==="
+        SUCCESS=0
+        FAILED=0
+        
+        for i in {1..10}; do
+          echo -n "Request $i: "
+          RESPONSE=$(curl -s -w "%{http_code}" -o /tmp/response.json -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Bulk test request '$i'"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions)
+          
+          if [ "$RESPONSE" = "200" ]; then
+            echo "✅ Success"
+            ((SUCCESS++))
+          else
+            echo "❌ Failed (Status: $RESPONSE)"
+            ((FAILED++))
+          fi
+        done
+        
+        echo -e "\n=== Summary ==="
+        echo "Successful: $SUCCESS"
+        echo "Failed: $FAILED"
+
+  test-timeout:
+    desc: "Test timeout and fallback behavior"
+    cmds:
+      - task: simulate-primary-slowness
+      - |
+        echo "=== Testing timeout scenario (primary slow, should use fallback) ==="
+        START=$(date +%s)
+        curl -s -H "Content-Type: application/json" \
+          -d '{
+            "model": "{{.MODEL}}",
+            "messages": [{"role": "user", "content": "Test timeout behavior"}]
+          }' \
+          http://localhost:{{.PORT_FORWARD}}/v1/chat/completions | jq .
+        END=$(date +%s)
+        echo "Response time: $((END-START)) seconds"
+      - task: simulate-primary-recovery
+
+  test-circuit-breaker:
+    desc: "Test circuit breaker activation"
+    cmds:
+      - |
+        echo "=== Testing circuit breaker (send many failures to open circuit) ==="
+        task simulate-primary-failure
+        
+        echo "Sending 10 rapid requests to trigger circuit breaker..."
+        for i in {1..10}; do
+          curl -s -H "Content-Type: application/json" \
+            -d '{
+              "model": "{{.MODEL}}",
+              "messages": [{"role": "user", "content": "Circuit breaker test '$i'"}]
+            }' \
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions > /dev/null
+          echo -n "."
+        done
+        echo -e "\n"
+        
+        echo "Circuit breaker should now be open. Testing final request:"
+        curl -s -H "Content-Type: application/json" \
+          -d '{
+            "model": "{{.MODEL}}",
+            "messages": [{"role": "user", "content": "Final test after circuit open"}]
+          }' \
+          http://localhost:{{.PORT_FORWARD}}/v1/chat/completions | jq .
+        
+        task simulate-primary-recovery
+
+  test-primary-health:
+    desc: "Check primary provider health"
+    cmds:
+      - |
+        echo "=== Checking primary provider health ==="
+        kubectl exec -n {{.NAMESPACE}} deploy/{{.PRIMARY_BACKEND}} -- curl -s localhost:8000/v1/models | jq . || echo "Primary provider unhealthy"
+
+  simulate-primary-failure:
+    desc: "Make primary backend return errors"
+    cmds:
+      - |
+        echo "Configuring primary backend to fail..."
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} FAILURE_RATE=100
+        kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
+        echo "Primary backend now returning errors"
+
+  simulate-primary-recovery:
+    desc: "Restore primary backend to healthy state"
+    cmds:
+      - |
+        echo "Restoring primary backend to healthy state..."
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} FAILURE_RATE=20
+        kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
+        echo "Primary backend restored (80% success rate)"
+
+  simulate-primary-slowness:
+    desc: "Make primary backend slow (timeout scenario)"
+    cmds:
+      - |
+        echo "Configuring primary backend to be slow..."
+        kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} RESPONSE_DELAY=15
+        kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
+        echo "Primary backend now slow (15s delay)"
+
+  logs:
+    desc: "Show logs from all components"
+    cmds:
+      - task: logs-primary
+      - task: logs-fallback
+      - task: logs-gateway
+
+  logs-primary:
+    desc: "Show logs from primary provider"
+    cmds:
+      - echo "=== Primary Provider Logs ==="
+      - kubectl logs -l app={{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} --tail=10
+
+  logs-fallback:
+    desc: "Show logs from fallback provider"
+    cmds:
+      - echo "=== Fallback Provider Logs ==="
+      - kubectl logs -l app={{.FALLBACK_BACKEND}} -n {{.NAMESPACE}} --tail=10
+
+  logs-gateway:
+    desc: "Show gateway logs with retry/fallback events"
+    cmds:
+      - |
+        echo "=== Gateway Logs (retry/fallback events) ==="
+        ENVOY_POD=$(kubectl get pods -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-name={{.GATEWAY_NAME}} -o jsonpath='{.items[0].metadata.name}')
+        kubectl logs -n envoy-gateway-system $ENVOY_POD --tail=20 | grep -E "(retry|fallback|circuit|timeout)" || echo "No retry/fallback events in recent logs"
+
+  metrics:
+    desc: "Show fallback and retry metrics"
+    cmds:
+      - |
+        ENVOY_POD=$(kubectl get pods -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-name={{.GATEWAY_NAME}} -o jsonpath='{.items[0].metadata.name}')
+        echo "Collecting metrics from Envoy pod: $ENVOY_POD"
+        
+        # Port forward to admin interface
+        kubectl port-forward -n envoy-gateway-system $ENVOY_POD 19000:19000 &
+        PF_PID=$!
+        sleep 3
+        
+        echo "=== Upstream Metrics ==="
+        STATS=$(curl -s localhost:19000/stats)
+        
+        echo "--- Primary Provider ({{.PRIMARY_BACKEND}}) ---"
+        echo "$STATS" | grep -E "cluster\.backend/default/{{.PRIMARY_BACKEND}}.*\.(upstream_rq_total|upstream_rq_5xx|upstream_rq_timeout|upstream_rq_retry|circuit_breakers)" | head -10
+        
+        echo -e "\n--- Fallback Provider ({{.FALLBACK_BACKEND}}) ---"
+        echo "$STATS" | grep -E "cluster\.backend/default/{{.FALLBACK_BACKEND}}.*\.(upstream_rq_total|upstream_rq_5xx|upstream_rq_timeout|upstream_rq_retry)" | head -10
+        
+        echo -e "\n=== Retry Metrics ==="
+        echo "$STATS" | grep -E "cluster\..*\.upstream_rq_retry(_success|_overflow):" | head -10
+        
+        echo -e "\n=== Circuit Breaker Status ==="
+        echo "$STATS" | grep -E "circuit_breakers\..*\.(rq_open|cx_open|rq_pending_open):" | head -10
+        
+        kill $PF_PID 2>/dev/null || true
+
+  status:
+    desc: "Check status of all components"
+    cmds:
+      - echo "=== Deployments ==="
+      - kubectl get deployments -n {{.NAMESPACE}} -l "app in ({{.PRIMARY_BACKEND}},{{.FALLBACK_BACKEND}})"
+      - echo -e "\n=== Pods ==="
+      - kubectl get pods -n {{.NAMESPACE}} -l "app in ({{.PRIMARY_BACKEND}},{{.FALLBACK_BACKEND}})"
+      - echo -e "\n=== Services ==="
+      - kubectl get svc -n {{.NAMESPACE}} | grep -E "({{.PRIMARY_BACKEND}}|{{.FALLBACK_BACKEND}})"
+      - echo -e "\n=== AI Routes ==="
+      - kubectl get aigatewayroute -n {{.NAMESPACE}}
+      - echo -e "\n=== Backend Traffic Policy ==="
+      - kubectl get backendtrafficpolicy -n {{.NAMESPACE}}
+
+  show-config:
+    desc: "Show applied configuration using kubectl"
+    cmds:
+      - echo "=== AI Gateway Route Configuration ==="
+      - kubectl get aigatewayroute -n {{.NAMESPACE}} provider-fallback-route -o yaml
+      - echo -e "\n=== Backend Traffic Policy Configuration ==="
+      - kubectl get backendtrafficpolicy -n {{.NAMESPACE}} retry-policy -o yaml
+
+  cleanup:
+    desc: "Clean up all demo resources"
+    cmds:
+      - kubectl delete -f primary-backend.yaml --ignore-not-found=true
+      - kubectl delete -f fallback-backend.yaml --ignore-not-found=true
+      - kubectl delete -f aigatewayroute-with-fallback.yaml --ignore-not-found=true
+      - kubectl delete -f retry-policy.yaml --ignore-not-found=true
+      - rm -rf .task/
+      - echo "Cleanup complete"

--- a/demos/03-provider-fallback/Taskfile.yml
+++ b/demos/03-provider-fallback/Taskfile.yml
@@ -5,7 +5,7 @@ vars:
   GATEWAY_NAME: envoy-ai-gateway
   PRIMARY_BACKEND: llm-primary
   FALLBACK_BACKEND: llm-fallback
-  MODEL: gpt-4
+  MODEL: qwen3
   PORT_FORWARD: 8080
 
 tasks:
@@ -15,10 +15,10 @@ tasks:
       - task --list --sort=none
 
   prerequisites:
-    desc: "Ensure base environment is ready"
+    desc: "Ensure 01-getting-started is deployed"
     dir: ../01-getting-started
     cmds:
-      - task prerequisites
+      - task setup
 
   setup:
     desc: "Complete setup of the provider fallback demo"
@@ -53,56 +53,16 @@ tasks:
       - sleep 5
 
   port-forward:
-    desc: "Start port forwarding to gateway"
+    desc: "Start port forwarding (delegates to 01-getting-started)"
+    dir: ../01-getting-started
     cmds:
-      - |
-        # Check if port-forward is already running
-        if [ -f .task/port-forward.pid ]; then
-          PID=$(cat .task/port-forward.pid)
-          if kill -0 $PID 2>/dev/null; then
-            echo "Port forwarding already running on PID $PID"
-            exit 0
-          fi
-        fi
-        
-        # Start port forwarding in background
-        mkdir -p .task
-        ENVOY_SERVICE=$(kubectl get svc -n envoy-gateway-system -l gateway.envoyproxy.io/owning-gateway-name={{.GATEWAY_NAME}} -o jsonpath='{.items[0].metadata.name}')
-        echo "Starting port forwarding to service: $ENVOY_SERVICE on port {{.PORT_FORWARD}}"
-        nohup kubectl port-forward -n envoy-gateway-system svc/$ENVOY_SERVICE {{.PORT_FORWARD}}:80 > .task/port-forward.log 2>&1 &
-        echo $! > .task/port-forward.pid
-        
-        # Wait for port forwarding to be ready
-        echo "Waiting for port forwarding to be ready..."
-        sleep 3
-        echo "✅ Port forwarding started in background (PID: $(cat .task/port-forward.pid))"
-        echo "Use 'task stop-port-forward' to stop"
-    generates:
-      - .task/port-forward.pid
-    status:
-      - test -f .task/port-forward.pid
-      - kill -0 $(cat .task/port-forward.pid 2>/dev/null) 2>/dev/null
+      - task port-forward
 
   stop-port-forward:
-    desc: "Stop background port forwarding"
+    desc: "Stop port forwarding (delegates to 01-getting-started)"
+    dir: ../01-getting-started
     cmds:
-      - |
-        if [ -f .task/port-forward.pid ]; then
-          PID=$(cat .task/port-forward.pid)
-          if kill -0 $PID 2>/dev/null; then
-            echo "Stopping port forwarding (PID: $PID)"
-            kill $PID
-            sleep 2
-            kill -9 $PID 2>/dev/null || true
-            echo "✅ Port forwarding stopped"
-          else
-            echo "Port forwarding process not running"
-          fi
-          rm -f .task/port-forward.pid .task/port-forward.log
-        else
-          echo "No port forwarding process found"
-        fi
-        pkill -f "kubectl.*port-forward.*{{.PORT_FORWARD}}" || true
+      - task stop-port-forward
 
   test:
     desc: "Run all test scenarios"
@@ -122,7 +82,7 @@ tasks:
               "model": "{{.MODEL}}",
               "messages": [{"role": "user", "content": "Test normal operation"}]
             }' \
-            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions | jq -r '.choices[0].message.content // .error // .'
+            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions | jq -c .
         done
 
   test-primary-failure:

--- a/demos/03-provider-fallback/Taskfile.yml
+++ b/demos/03-provider-fallback/Taskfile.yml
@@ -28,6 +28,7 @@ tasks:
       - task: wait-ready
       - echo "Provider fallback setup complete!"
       - echo "Run 'task test' to test the fallback behavior"
+      - task: port-forward
     generates:
       - .task/setup.done
     status:
@@ -364,11 +365,8 @@ tasks:
       - |
         echo "Configuring primary backend to return rate limit errors..."
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
-          LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=80 \
-          LLM_D_FAILURE_TYPE_1=rate_limit \
-          LLM_D_FAILURE_TYPE_2="" \
-          LLM_D_FAILURE_TYPE_3=""
+          LLM_D_FAILURE_TYPE=rate_limit
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 80% rate limit errors (HTTP 429)"
 
@@ -378,11 +376,8 @@ tasks:
       - |
         echo "Configuring primary backend to return auth errors..."
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
-          LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=70 \
-          LLM_D_FAILURE_TYPE_1=invalid_api_key \
-          LLM_D_FAILURE_TYPE_2="" \
-          LLM_D_FAILURE_TYPE_3=""
+          LLM_D_FAILURE_TYPE=invalid_api_key
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 70% auth errors (HTTP 401)"
 
@@ -392,11 +387,8 @@ tasks:
       - |
         echo "Configuring primary backend to return context length errors..."
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
-          LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=60 \
-          LLM_D_FAILURE_TYPE_1=context_length \
-          LLM_D_FAILURE_TYPE_2="" \
-          LLM_D_FAILURE_TYPE_3=""
+          LLM_D_FAILURE_TYPE=context_length
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 60% context length errors (HTTP 400)"
 
@@ -406,11 +398,8 @@ tasks:
       - |
         echo "Configuring primary backend to return server errors..."
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
-          LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=90 \
-          LLM_D_FAILURE_TYPE_1=server_error \
-          LLM_D_FAILURE_TYPE_2="" \
-          LLM_D_FAILURE_TYPE_3=""
+          LLM_D_FAILURE_TYPE=server_error
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 90% server errors (HTTP 503)"
 
@@ -420,11 +409,8 @@ tasks:
       - |
         echo "Configuring primary backend to return model not found errors..."
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
-          LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=50 \
-          LLM_D_FAILURE_TYPE_1=model_not_found \
-          LLM_D_FAILURE_TYPE_2="" \
-          LLM_D_FAILURE_TYPE_3=""
+          LLM_D_FAILURE_TYPE=model_not_found
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 50% model not found errors (HTTP 404)"
 
@@ -434,11 +420,8 @@ tasks:
       - |
         echo "Configuring primary backend with mixed failures..."
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
-          LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=75 \
-          LLM_D_FAILURE_TYPE_1=rate_limit \
-          LLM_D_FAILURE_TYPE_2=server_error \
-          LLM_D_FAILURE_TYPE_3=context_length
+
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 75% mixed failures (rate_limit, server_error, context_length)"
 
@@ -455,9 +438,7 @@ tasks:
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
           LLM_D_MODE=random \
           LLM_D_FAILURE_INJECTION_RATE=0 \
-          LLM_D_FAILURE_TYPE_1="" \
-          LLM_D_FAILURE_TYPE_2="" \
-          LLM_D_FAILURE_TYPE_3=""
+          LLM_D_FAILURE_TYPE=""
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend restored to healthy random mode"
 

--- a/demos/03-provider-fallback/Taskfile.yml
+++ b/demos/03-provider-fallback/Taskfile.yml
@@ -479,53 +479,6 @@ tasks:
         ENVOY_POD=$(kubectl get pods -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-name={{.GATEWAY_NAME}} -o jsonpath='{.items[0].metadata.name}')
         kubectl logs -n envoy-gateway-system $ENVOY_POD --tail=20 | jq -c .
 
-  show-retry-evidence:
-    desc: "Show evidence of retry behavior and timeout differences"
-    cmds:
-      - |
-        echo "=== RETRY POLICY STATUS ==="
-        kubectl get backendtrafficpolicy retry-policy -n {{.NAMESPACE}} -o yaml 2>/dev/null || echo "❌ Retry policy not found"
-        
-        echo -e "\n=== GATEWAY RETRY METRICS ==="
-        ENVOY_POD=$(kubectl get pods -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-name={{.GATEWAY_NAME}} -o jsonpath='{.items[0].metadata.name}')
-        
-        # Port forward to admin interface for detailed metrics
-        kubectl port-forward -n envoy-gateway-system $ENVOY_POD 19001:19000 &
-        PF_PID=$!
-        sleep 3
-        
-        echo "📊 Upstream Request Metrics:"
-        STATS=$(curl -s localhost:19001/stats)
-        
-        echo "--- Primary Backend Stats ---"
-        echo "$STATS" | grep -E "cluster\.backend/default/{{.PRIMARY_BACKEND}}.*\.(upstream_rq_total|upstream_rq_5xx|upstream_rq_timeout|upstream_rq_retry|upstream_rq_retry_success|upstream_cx_connect_fail):" | head -10
-        
-        echo -e "\n--- Fallback Backend Stats ---"
-        echo "$STATS" | grep -E "cluster\.backend/default/{{.FALLBACK_BACKEND}}.*\.(upstream_rq_total|upstream_rq_2xx|upstream_rq_timeout):" | head -10
-        
-        echo -e "\n--- Retry-Specific Metrics ---"
-        echo "$STATS" | grep -E "retry\.(upstream_rq_retry|upstream_rq_retry_success|upstream_rq_retry_overflow):" || echo "No retry metrics found"
-        
-        echo -e "\n--- Circuit Breaker Status ---"
-        echo "$STATS" | grep -E "circuit_breakers\..*\.(rq_open|cx_open):" | head -5
-        
-        echo -e "\n=== RECENT GATEWAY LOGS (showing retry attempts) ==="
-        kubectl logs -n envoy-gateway-system $ENVOY_POD --tail=30 | grep -E "(retry|upstream_rq|timeout|circuit)" | tail -10 || echo "No retry-related logs in recent entries"
-        
-        kill $PF_PID 2>/dev/null || true
-        
-        echo -e "\n=== TIMEOUT COMPARISON GUIDE ==="
-        echo "🕐 EXPECTED TIMING PATTERNS:"
-        echo "   • No Retry Policy: ~1-5 seconds (fast failure)"
-        echo "   • With Retry Policy: ~30-150 seconds (depends on failure type and retry success)"
-        echo "   • Successful Fallback: Should complete within retry timeout"
-        echo ""
-        echo "🔍 EVIDENCE TO LOOK FOR:"
-        echo "   1. upstream_rq_retry > 0 (retry attempts made)"
-        echo "   2. Different response times in test phases"
-        echo "   3. Primary backend errors followed by fallback success"
-        echo "   4. Circuit breaker activation after multiple failures"
-
   metrics:
     desc: "Show fallback and retry metrics"
     cmds:

--- a/demos/03-provider-fallback/Taskfile.yml
+++ b/demos/03-provider-fallback/Taskfile.yml
@@ -260,54 +260,19 @@ tasks:
         done
 
   test-primary-failure:
-    desc: "Test failover when primary fails"
+    desc: "Interactive timeout analysis demo - compares behavior with/without retry policy"
     cmds:
-      - task: simulate-primary-failure
       - |
-        echo "=== Testing with primary failure (should failover to fallback) ==="
-        for i in {1..3}; do
-          echo -e "\nRequest $i:"
-          RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}" -H "Content-Type: application/json" \
-            -d '{
-              "model": "{{.MODEL}}",
-              "messages": [{"role": "user", "content": "Test with primary failure"}]
-            }' \
-            http://localhost:{{.PORT_FORWARD}}/v1/chat/completions)
-          
-          HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
-          BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d')
-          
-          echo "Status: $HTTP_STATUS"
-          echo "$BODY" | jq -r '.choices[0].message.content // .error // .' 2>/dev/null || echo "$BODY"
-          
-          # Check which backend served the request
-          echo "Checking which backend served this request..."
-          FALLBACK_LOGS=$(kubectl logs -l app={{.FALLBACK_BACKEND}} -n {{.NAMESPACE}} --tail=5 2>/dev/null | grep -E "(POST|GET|chat|completions)" | tail -1)
-          PRIMARY_LOGS=$(kubectl logs -l app={{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} --tail=5 2>/dev/null | grep -E "(POST|GET|chat|completions)" | tail -1)
-          
-          if [[ -n "$FALLBACK_LOGS" ]]; then
-            echo "✅ CONFIRMED: Request served by FALLBACK backend"
-          elif [[ -n "$PRIMARY_LOGS" ]]; then
-            echo "⚠️  Request served by primary backend (fallback may not have activated)"
-          else
-            echo "❓ Unable to determine which backend served the request"
-          fi
-        done
-      - |
-        echo -e "\n=== Recovery Options ==="
-        echo "Primary backend is currently configured to fail."
-        echo "Options:"
-        echo "1. Keep primary failed for further testing"
-        echo "2. Recover primary to healthy state"
-        echo ""
-        read -p "Do you want to recover the primary backend now? (y/N): " RECOVER
-        if [[ "$RECOVER" == "y" || "$RECOVER" == "Y" ]]; then
-          echo "Recovering primary backend..."
-          task simulate-primary-recovery
-        else
-          echo "Primary backend remains in failed state."
-          echo "Use 'task simulate-primary-recovery' to recover it later."
-        fi
+        # Export environment variables for the script
+        export NAMESPACE={{.NAMESPACE}}
+        export GATEWAY_NAME={{.GATEWAY_NAME}}
+        export PRIMARY_BACKEND={{.PRIMARY_BACKEND}}
+        export FALLBACK_BACKEND={{.FALLBACK_BACKEND}}
+        export MODEL={{.MODEL}}
+        export PORT_FORWARD={{.PORT_FORWARD}}
+        
+        # Run the interactive timeout analysis script
+        ./test-timeout-analysis.sh
 
   test-bulk-failures:
     desc: "Send multiple requests to observe fallback behavior"
@@ -401,7 +366,9 @@ tasks:
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
           LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=80 \
-          LLM_D_FAILURE_TYPES=rate_limit
+          LLM_D_FAILURE_TYPE_1=rate_limit \
+          LLM_D_FAILURE_TYPE_2="" \
+          LLM_D_FAILURE_TYPE_3=""
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 80% rate limit errors (HTTP 429)"
 
@@ -413,7 +380,9 @@ tasks:
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
           LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=70 \
-          LLM_D_FAILURE_TYPES=invalid_api_key
+          LLM_D_FAILURE_TYPE_1=invalid_api_key \
+          LLM_D_FAILURE_TYPE_2="" \
+          LLM_D_FAILURE_TYPE_3=""
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 70% auth errors (HTTP 401)"
 
@@ -425,7 +394,9 @@ tasks:
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
           LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=60 \
-          LLM_D_FAILURE_TYPES=context_length
+          LLM_D_FAILURE_TYPE_1=context_length \
+          LLM_D_FAILURE_TYPE_2="" \
+          LLM_D_FAILURE_TYPE_3=""
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 60% context length errors (HTTP 400)"
 
@@ -437,7 +408,9 @@ tasks:
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
           LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=90 \
-          LLM_D_FAILURE_TYPES=server_error
+          LLM_D_FAILURE_TYPE_1=server_error \
+          LLM_D_FAILURE_TYPE_2="" \
+          LLM_D_FAILURE_TYPE_3=""
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 90% server errors (HTTP 503)"
 
@@ -449,7 +422,9 @@ tasks:
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
           LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=50 \
-          LLM_D_FAILURE_TYPES=model_not_found
+          LLM_D_FAILURE_TYPE_1=model_not_found \
+          LLM_D_FAILURE_TYPE_2="" \
+          LLM_D_FAILURE_TYPE_3=""
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 50% model not found errors (HTTP 404)"
 
@@ -461,7 +436,9 @@ tasks:
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
           LLM_D_MODE=failure \
           LLM_D_FAILURE_INJECTION_RATE=75 \
-          LLM_D_FAILURE_TYPES=rate_limit,server_error,context_length
+          LLM_D_FAILURE_TYPE_1=rate_limit \
+          LLM_D_FAILURE_TYPE_2=server_error \
+          LLM_D_FAILURE_TYPE_3=context_length
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
         echo "Primary backend now returning 75% mixed failures (rate_limit, server_error, context_length)"
 
@@ -476,11 +453,13 @@ tasks:
       - |
         echo "Restoring primary backend to healthy state..."
         kubectl set env deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}} \
-          LLM_D_MODE=echo \
-          LLM_D_FAILURE_INJECTION_RATE- \
-          LLM_D_FAILURE_TYPES-
+          LLM_D_MODE=random \
+          LLM_D_FAILURE_INJECTION_RATE=0 \
+          LLM_D_FAILURE_TYPE_1="" \
+          LLM_D_FAILURE_TYPE_2="" \
+          LLM_D_FAILURE_TYPE_3=""
         kubectl rollout status deployment/{{.PRIMARY_BACKEND}} -n {{.NAMESPACE}}
-        echo "Primary backend restored to healthy echo mode"
+        echo "Primary backend restored to healthy random mode"
 
   simulate-primary-slowness:
     desc: "Make primary backend slow (timeout scenario)"
@@ -518,6 +497,53 @@ tasks:
         echo "=== Gateway Logs (retry/fallback events) ==="
         ENVOY_POD=$(kubectl get pods -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-name={{.GATEWAY_NAME}} -o jsonpath='{.items[0].metadata.name}')
         kubectl logs -n envoy-gateway-system $ENVOY_POD --tail=20 | jq -c .
+
+  show-retry-evidence:
+    desc: "Show evidence of retry behavior and timeout differences"
+    cmds:
+      - |
+        echo "=== RETRY POLICY STATUS ==="
+        kubectl get backendtrafficpolicy retry-policy -n {{.NAMESPACE}} -o yaml 2>/dev/null || echo "❌ Retry policy not found"
+        
+        echo -e "\n=== GATEWAY RETRY METRICS ==="
+        ENVOY_POD=$(kubectl get pods -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-name={{.GATEWAY_NAME}} -o jsonpath='{.items[0].metadata.name}')
+        
+        # Port forward to admin interface for detailed metrics
+        kubectl port-forward -n envoy-gateway-system $ENVOY_POD 19001:19000 &
+        PF_PID=$!
+        sleep 3
+        
+        echo "📊 Upstream Request Metrics:"
+        STATS=$(curl -s localhost:19001/stats)
+        
+        echo "--- Primary Backend Stats ---"
+        echo "$STATS" | grep -E "cluster\.backend/default/{{.PRIMARY_BACKEND}}.*\.(upstream_rq_total|upstream_rq_5xx|upstream_rq_timeout|upstream_rq_retry|upstream_rq_retry_success|upstream_cx_connect_fail):" | head -10
+        
+        echo -e "\n--- Fallback Backend Stats ---"
+        echo "$STATS" | grep -E "cluster\.backend/default/{{.FALLBACK_BACKEND}}.*\.(upstream_rq_total|upstream_rq_2xx|upstream_rq_timeout):" | head -10
+        
+        echo -e "\n--- Retry-Specific Metrics ---"
+        echo "$STATS" | grep -E "retry\.(upstream_rq_retry|upstream_rq_retry_success|upstream_rq_retry_overflow):" || echo "No retry metrics found"
+        
+        echo -e "\n--- Circuit Breaker Status ---"
+        echo "$STATS" | grep -E "circuit_breakers\..*\.(rq_open|cx_open):" | head -5
+        
+        echo -e "\n=== RECENT GATEWAY LOGS (showing retry attempts) ==="
+        kubectl logs -n envoy-gateway-system $ENVOY_POD --tail=30 | grep -E "(retry|upstream_rq|timeout|circuit)" | tail -10 || echo "No retry-related logs in recent entries"
+        
+        kill $PF_PID 2>/dev/null || true
+        
+        echo -e "\n=== TIMEOUT COMPARISON GUIDE ==="
+        echo "🕐 EXPECTED TIMING PATTERNS:"
+        echo "   • No Retry Policy: ~1-5 seconds (fast failure)"
+        echo "   • With Retry Policy: ~30-150 seconds (depends on failure type and retry success)"
+        echo "   • Successful Fallback: Should complete within retry timeout"
+        echo ""
+        echo "🔍 EVIDENCE TO LOOK FOR:"
+        echo "   1. upstream_rq_retry > 0 (retry attempts made)"
+        echo "   2. Different response times in test phases"
+        echo "   3. Primary backend errors followed by fallback success"
+        echo "   4. Circuit breaker activation after multiple failures"
 
   metrics:
     desc: "Show fallback and retry metrics"

--- a/demos/03-provider-fallback/aigatewayroute-with-fallback.yaml
+++ b/demos/03-provider-fallback/aigatewayroute-with-fallback.yaml
@@ -1,0 +1,27 @@
+---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIGatewayRoute
+metadata:
+  name: provider-fallback-route
+  namespace: default
+spec:
+  schema:
+    name: OpenAI
+  parentRefs:
+    - name: envoy-ai-gateway
+      kind: Gateway
+      group: gateway.networking.k8s.io
+  rules:
+    # Route for gpt-4 model with fallback support
+    - matches:
+        - headers:
+            - type: Exact
+              name: x-ai-eg-model
+              value: gpt-4
+      # Multiple backend refs enable fallback behavior
+      # Traffic will go to primary first, then fallback on failure
+      backendRefs:
+        - name: llm-primary-backend
+          weight: 1
+        - name: llm-fallback-backend
+          weight: 1

--- a/demos/03-provider-fallback/fallback-backend.yaml
+++ b/demos/03-provider-fallback/fallback-backend.yaml
@@ -1,0 +1,90 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-fallback
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm-fallback
+  template:
+    metadata:
+      labels:
+        app: llm-fallback
+    spec:
+      containers:
+        - name: simulator
+          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          args:
+            - "--port"
+            - "8001"
+            - "--model"
+            - "gpt-4"
+            - "--mode"
+            - "echo"
+            - "--time-to-first-token"
+            - "100"
+            - "--inter-token-latency"
+            - "20"
+          ports:
+            - containerPort: 8001
+              name: http
+          livenessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8001
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8001
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-fallback
+  namespace: default
+spec:
+  selector:
+    app: llm-fallback
+  ports:
+    - port: 8001
+      targetPort: 8001
+      protocol: TCP
+  type: ClusterIP
+---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIServiceBackend
+metadata:
+  name: llm-fallback-backend
+  namespace: default
+spec:
+  schema:
+    name: OpenAI
+  backendRef:
+    name: llm-fallback-backend-ref
+    kind: Backend
+    group: gateway.envoyproxy.io
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: llm-fallback-backend-ref
+  namespace: default
+spec:
+  endpoints:
+    - fqdn:
+        hostname: llm-fallback.default.svc.cluster.local
+        port: 8001

--- a/demos/03-provider-fallback/fallback-backend.yaml
+++ b/demos/03-provider-fallback/fallback-backend.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: simulator
-          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:d5738db4c1498790a830f73776a1f6b130c2fa15
+          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:972092ae660fc2628cd18571be8c50a59ff59ea9
           args:
             - "--port"
             - "$(LLM_D_PORT)"
@@ -35,7 +35,9 @@ spec:
             - "--failure-injection-rate"
             - "$(LLM_D_FAILURE_INJECTION_RATE)"
             - "--failure-types"
-            - "$(LLM_D_FAILURE_TYPES)"
+            - "$(LLM_D_FAILURE_TYPE_1)"
+            - "$(LLM_D_FAILURE_TYPE_2)"
+            - "$(LLM_D_FAILURE_TYPE_3)"
           ports:
             - containerPort: 8001
               name: http
@@ -62,7 +64,11 @@ spec:
             # Failure Mode Configuration (fallback should be reliable)
             - name: LLM_D_FAILURE_INJECTION_RATE
               value: "0"
-            - name: LLM_D_FAILURE_TYPES
+            - name: LLM_D_FAILURE_TYPE_1
+              value: ""
+            - name: LLM_D_FAILURE_TYPE_2
+              value: ""
+            - name: LLM_D_FAILURE_TYPE_3
               value: ""
           livenessProbe:
             httpGet:

--- a/demos/03-provider-fallback/fallback-backend.yaml
+++ b/demos/03-provider-fallback/fallback-backend.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: simulator
-          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:972092ae660fc2628cd18571be8c50a59ff59ea9
+          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:8239ac1527d6b47dab5019bffe51a115080361cf
           args:
             - "--port"
             - "$(LLM_D_PORT)"
@@ -35,9 +35,7 @@ spec:
             - "--failure-injection-rate"
             - "$(LLM_D_FAILURE_INJECTION_RATE)"
             - "--failure-types"
-            - "$(LLM_D_FAILURE_TYPE_1)"
-            - "$(LLM_D_FAILURE_TYPE_2)"
-            - "$(LLM_D_FAILURE_TYPE_3)"
+            - "$(LLM_D_FAILURE_TYPE)"
           ports:
             - containerPort: 8001
               name: http
@@ -64,11 +62,7 @@ spec:
             # Failure Mode Configuration (fallback should be reliable)
             - name: LLM_D_FAILURE_INJECTION_RATE
               value: "0"
-            - name: LLM_D_FAILURE_TYPE_1
-              value: ""
-            - name: LLM_D_FAILURE_TYPE_2
-              value: ""
-            - name: LLM_D_FAILURE_TYPE_3
+            - name: LLM_D_FAILURE_TYPE
               value: ""
           livenessProbe:
             httpGet:

--- a/demos/03-provider-fallback/fallback-backend.yaml
+++ b/demos/03-provider-fallback/fallback-backend.yaml
@@ -16,21 +16,54 @@ spec:
     spec:
       containers:
         - name: simulator
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:d5738db4c1498790a830f73776a1f6b130c2fa15
           args:
             - "--port"
-            - "8001"
+            - "$(LLM_D_PORT)"
             - "--model"
-            - "gpt-4"
+            - "$(LLM_D_MODEL)"
             - "--mode"
-            - "echo"
+            - "$(LLM_D_MODE)"
             - "--time-to-first-token"
-            - "100"
+            - "$(LLM_D_TIME_TO_FIRST_TOKEN)"
+            - "--time-to-first-token-std-dev"
+            - "$(LLM_D_TIME_TO_FIRST_TOKEN_STD_DEV)"
             - "--inter-token-latency"
-            - "20"
+            - "$(LLM_D_INTER_TOKEN_LATENCY)"
+            - "--inter-token-latency-std-dev"
+            - "$(LLM_D_INTER_TOKEN_LATENCY_STD_DEV)"
+            - "--failure-injection-rate"
+            - "$(LLM_D_FAILURE_INJECTION_RATE)"
+            - "--failure-types"
+            - "$(LLM_D_FAILURE_TYPES)"
           ports:
             - containerPort: 8001
               name: http
+          env:
+            # Core LLM-D Configuration  
+            - name: LLM_D_PORT
+              value: "8001"
+            - name: LLM_D_MODEL
+              value: "gpt-4"
+            - name: LLM_D_MODE
+              value: "echo"
+            
+            # Performance Settings (optimized for fallback - fast and reliable)
+            - name: LLM_D_TIME_TO_FIRST_TOKEN
+              value: "100"
+            - name: LLM_D_TIME_TO_FIRST_TOKEN_STD_DEV
+              value: "10"
+            - name: LLM_D_INTER_TOKEN_LATENCY
+              value: "20"
+            - name: LLM_D_INTER_TOKEN_LATENCY_STD_DEV
+              value: "5"
+            - name: LLM_D_RESPONSE_DELAY
+              value: "0"
+            # Failure Mode Configuration (fallback should be reliable)
+            - name: LLM_D_FAILURE_INJECTION_RATE
+              value: "0"
+            - name: LLM_D_FAILURE_TYPES
+              value: ""
           livenessProbe:
             httpGet:
               path: /v1/models

--- a/demos/03-provider-fallback/primary-backend.yaml
+++ b/demos/03-provider-fallback/primary-backend.yaml
@@ -27,11 +27,11 @@ spec:
             - "--time-to-first-token"
             - "500"
             - "--time-to-first-token-std-dev"
-            - "200"
+            - "100"
             - "--inter-token-latency"
             - "50"
             - "--inter-token-latency-std-dev"
-            - "20"
+            - "10"
           ports:
             - containerPort: 8000
               name: http

--- a/demos/03-provider-fallback/primary-backend.yaml
+++ b/demos/03-provider-fallback/primary-backend.yaml
@@ -16,30 +16,54 @@ spec:
     spec:
       containers:
         - name: simulator
-          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:d5738db4c1498790a830f73776a1f6b130c2fa15
           args:
             - "--port"
-            - "8000"
+            - "$(LLM_D_PORT)"
             - "--model"
-            - "gpt-4"
+            - "$(LLM_D_MODEL)"
             - "--mode"
-            - "random"
+            - "$(LLM_D_MODE)"
             - "--time-to-first-token"
-            - "500"
+            - "$(LLM_D_TIME_TO_FIRST_TOKEN)"
             - "--time-to-first-token-std-dev"
-            - "100"
+            - "$(LLM_D_TIME_TO_FIRST_TOKEN_STD_DEV)"
             - "--inter-token-latency"
-            - "50"
+            - "$(LLM_D_INTER_TOKEN_LATENCY)"
             - "--inter-token-latency-std-dev"
-            - "10"
+            - "$(LLM_D_INTER_TOKEN_LATENCY_STD_DEV)"
+            - "--failure-injection-rate"
+            - "$(LLM_D_FAILURE_INJECTION_RATE)"
+            - "--failure-types"
+            - "$(LLM_D_FAILURE_TYPES)"
           ports:
             - containerPort: 8000
               name: http
           env:
-            - name: FAILURE_RATE
-              value: "20"
-            - name: RESPONSE_DELAY
+            # Core LLM-D Configuration
+            - name: LLM_D_PORT
+              value: "8000"
+            - name: LLM_D_MODEL
+              value: "gpt-4"
+            - name: LLM_D_MODE
+              value: "random"
+            
+            # Performance Settings
+            - name: LLM_D_TIME_TO_FIRST_TOKEN
+              value: "500"
+            - name: LLM_D_TIME_TO_FIRST_TOKEN_STD_DEV
+              value: "100"
+            - name: LLM_D_INTER_TOKEN_LATENCY
+              value: "50"
+            - name: LLM_D_INTER_TOKEN_LATENCY_STD_DEV
+              value: "10"
+            - name: LLM_D_RESPONSE_DELAY
               value: "0"
+            # Failure Mode Configuration
+            - name: LLM_D_FAILURE_INJECTION_RATE
+              value: "0"
+            - name: LLM_D_FAILURE_TYPES
+              value: ""
           livenessProbe:
             httpGet:
               path: /v1/models

--- a/demos/03-provider-fallback/primary-backend.yaml
+++ b/demos/03-provider-fallback/primary-backend.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: simulator
-          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:d5738db4c1498790a830f73776a1f6b130c2fa15
+          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:972092ae660fc2628cd18571be8c50a59ff59ea9
           args:
             - "--port"
             - "$(LLM_D_PORT)"
@@ -35,7 +35,9 @@ spec:
             - "--failure-injection-rate"
             - "$(LLM_D_FAILURE_INJECTION_RATE)"
             - "--failure-types"
-            - "$(LLM_D_FAILURE_TYPES)"
+            - "$(LLM_D_FAILURE_TYPE_1)"
+            - "$(LLM_D_FAILURE_TYPE_2)"
+            - "$(LLM_D_FAILURE_TYPE_3)"
           ports:
             - containerPort: 8000
               name: http
@@ -62,7 +64,11 @@ spec:
             # Failure Mode Configuration
             - name: LLM_D_FAILURE_INJECTION_RATE
               value: "0"
-            - name: LLM_D_FAILURE_TYPES
+            - name: LLM_D_FAILURE_TYPE_1
+              value: ""
+            - name: LLM_D_FAILURE_TYPE_2
+              value: ""
+            - name: LLM_D_FAILURE_TYPE_3
               value: ""
           livenessProbe:
             httpGet:

--- a/demos/03-provider-fallback/primary-backend.yaml
+++ b/demos/03-provider-fallback/primary-backend.yaml
@@ -1,0 +1,99 @@
+---
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: llm-primary
+  namespace: default
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: llm-primary
+  template:
+    metadata:
+      labels:
+        app: llm-primary
+    spec:
+      containers:
+        - name: simulator
+          image: ghcr.io/llm-d/llm-d-inference-sim:latest
+          args:
+            - "--port"
+            - "8000"
+            - "--model"
+            - "gpt-4"
+            - "--mode"
+            - "random"
+            - "--time-to-first-token"
+            - "500"
+            - "--time-to-first-token-std-dev"
+            - "200"
+            - "--inter-token-latency"
+            - "50"
+            - "--inter-token-latency-std-dev"
+            - "20"
+          ports:
+            - containerPort: 8000
+              name: http
+          env:
+            - name: FAILURE_RATE
+              value: "20"
+            - name: RESPONSE_DELAY
+              value: "0"
+          livenessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8000
+            initialDelaySeconds: 10
+            periodSeconds: 10
+          readinessProbe:
+            httpGet:
+              path: /v1/models
+              port: 8000
+            initialDelaySeconds: 5
+            periodSeconds: 5
+          resources:
+            requests:
+              memory: "128Mi"
+              cpu: "100m"
+            limits:
+              memory: "256Mi"
+              cpu: "500m"
+---
+apiVersion: v1
+kind: Service
+metadata:
+  name: llm-primary
+  namespace: default
+spec:
+  selector:
+    app: llm-primary
+  ports:
+    - port: 8000
+      targetPort: 8000
+      protocol: TCP
+  type: ClusterIP
+---
+apiVersion: aigateway.envoyproxy.io/v1alpha1
+kind: AIServiceBackend
+metadata:
+  name: llm-primary-backend
+  namespace: default
+spec:
+  schema:
+    name: OpenAI
+  backendRef:
+    name: llm-primary-backend-ref
+    kind: Backend
+    group: gateway.envoyproxy.io
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: Backend
+metadata:
+  name: llm-primary-backend-ref
+  namespace: default
+spec:
+  endpoints:
+    - fqdn:
+        hostname: llm-primary.default.svc.cluster.local
+        port: 8000

--- a/demos/03-provider-fallback/primary-backend.yaml
+++ b/demos/03-provider-fallback/primary-backend.yaml
@@ -16,7 +16,7 @@ spec:
     spec:
       containers:
         - name: simulator
-          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:972092ae660fc2628cd18571be8c50a59ff59ea9
+          image: us-east1-docker.pkg.dev/dogfood-cx/registryrepository/llm-d-inference-sim:8239ac1527d6b47dab5019bffe51a115080361cf
           args:
             - "--port"
             - "$(LLM_D_PORT)"
@@ -35,9 +35,7 @@ spec:
             - "--failure-injection-rate"
             - "$(LLM_D_FAILURE_INJECTION_RATE)"
             - "--failure-types"
-            - "$(LLM_D_FAILURE_TYPE_1)"
-            - "$(LLM_D_FAILURE_TYPE_2)"
-            - "$(LLM_D_FAILURE_TYPE_3)"
+            - "$(LLM_D_FAILURE_TYPE)"
           ports:
             - containerPort: 8000
               name: http
@@ -64,11 +62,7 @@ spec:
             # Failure Mode Configuration
             - name: LLM_D_FAILURE_INJECTION_RATE
               value: "0"
-            - name: LLM_D_FAILURE_TYPE_1
-              value: ""
-            - name: LLM_D_FAILURE_TYPE_2
-              value: ""
-            - name: LLM_D_FAILURE_TYPE_3
+            - name: LLM_D_FAILURE_TYPE
               value: ""
           livenessProbe:
             httpGet:

--- a/demos/03-provider-fallback/retry-policy.yaml
+++ b/demos/03-provider-fallback/retry-policy.yaml
@@ -1,0 +1,24 @@
+---
+apiVersion: gateway.envoyproxy.io/v1alpha1
+kind: BackendTrafficPolicy
+metadata:
+  name: retry-policy
+  namespace: default
+spec:
+  targetRefs:
+    - group: gateway.networking.k8s.io
+      kind: HTTPRoute
+      name: provider-fallback
+  retry:
+    numRetries: 5
+    perRetry:
+      backOff:
+        baseInterval: 100ms
+        maxInterval: 10s
+      timeout: 30s
+    retryOn:
+      httpStatusCodes:
+        - 500
+      triggers:
+        - connect-failure
+        - retriable-status-codes

--- a/demos/03-provider-fallback/retry-policy.yaml
+++ b/demos/03-provider-fallback/retry-policy.yaml
@@ -8,7 +8,7 @@ spec:
   targetRefs:
     - group: gateway.networking.k8s.io
       kind: HTTPRoute
-      name: provider-fallback
+      name: provider-fallback-route
   retry:
     numRetries: 5
     perRetry:
@@ -18,7 +18,7 @@ spec:
       timeout: 30s
     retryOn:
       httpStatusCodes:
-        - 500
+        - 503
       triggers:
         - connect-failure
         - retriable-status-codes

--- a/demos/03-provider-fallback/test-timeout-analysis.sh
+++ b/demos/03-provider-fallback/test-timeout-analysis.sh
@@ -43,11 +43,8 @@ sleep 3
 
 echo -e "${YELLOW}⚙️  Configuring primary backend to fail (90% server errors)...${NC}"
 kubectl set env deployment/$PRIMARY_BACKEND -n $NAMESPACE \
-  LLM_D_MODE=failure \
   LLM_D_FAILURE_INJECTION_RATE=90 \
-  LLM_D_FAILURE_TYPE_1=server_error \
-  LLM_D_FAILURE_TYPE_2="" \
-  LLM_D_FAILURE_TYPE_3=""
+  LLM_D_FAILURE_TYPE=server_error
 kubectl rollout status deployment/$PRIMARY_BACKEND -n $NAMESPACE
 
 echo ""
@@ -257,9 +254,7 @@ if [[ "$RECOVER" == "y" || "$RECOVER" == "Y" ]]; then
   kubectl set env deployment/$PRIMARY_BACKEND -n $NAMESPACE \
     LLM_D_MODE=random \
     LLM_D_FAILURE_INJECTION_RATE=0 \
-    LLM_D_FAILURE_TYPE_1="" \
-    LLM_D_FAILURE_TYPE_2="" \
-    LLM_D_FAILURE_TYPE_3=""
+    LLM_D_FAILURE_TYPE=""
   kubectl rollout status deployment/$PRIMARY_BACKEND -n $NAMESPACE
   echo -e "${GREEN}✅ Primary backend restored to healthy state${NC}"
 else

--- a/demos/03-provider-fallback/test-timeout-analysis.sh
+++ b/demos/03-provider-fallback/test-timeout-analysis.sh
@@ -1,0 +1,280 @@
+#!/bin/bash
+
+# Interactive Timeout Analysis Script for Provider Fallback Demo
+# This script demonstrates the difference between timeout behavior with and without retry policies
+
+set -e
+
+# Configuration
+NAMESPACE=${NAMESPACE:-default}
+GATEWAY_NAME=${GATEWAY_NAME:-envoy-ai-gateway}
+PRIMARY_BACKEND=${PRIMARY_BACKEND:-llm-primary}
+FALLBACK_BACKEND=${FALLBACK_BACKEND:-llm-fallback}
+MODEL=${MODEL:-gpt-4}
+PORT_FORWARD=${PORT_FORWARD:-8080}
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[0;33m'
+BLUE='\033[0;34m'
+PURPLE='\033[0;35m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color
+
+echo -e "${CYAN}🔬 INTERACTIVE TIMEOUT ANALYSIS DEMO${NC}"
+echo "====================================="
+echo ""
+echo "This test will demonstrate the difference between:"
+echo -e "1. ${RED}❌ NO retry policy${NC}: Fast failures"
+echo -e "2. ${GREEN}✅ WITH retry policy${NC}: Retries and eventual fallback success"
+echo ""
+echo "You'll see actual request/response data and timing measurements."
+echo ""
+read -p "Press ENTER to start Phase 1 (baseline without retry policy)..."
+
+echo -e "\n${BLUE}🚀 PHASE 1: Testing WITHOUT retry policy (baseline timeout behavior)${NC}"
+echo "=================================================================="
+
+# Temporarily remove retry policy to measure baseline behavior
+echo -e "${YELLOW}🗑️  Removing retry policy to establish baseline...${NC}"
+kubectl delete backendtrafficpolicy retry-policy -n $NAMESPACE --ignore-not-found=true
+sleep 3
+
+echo -e "${YELLOW}⚙️  Configuring primary backend to fail (90% server errors)...${NC}"
+kubectl set env deployment/$PRIMARY_BACKEND -n $NAMESPACE \
+  LLM_D_MODE=failure \
+  LLM_D_FAILURE_INJECTION_RATE=90 \
+  LLM_D_FAILURE_TYPE_1=server_error \
+  LLM_D_FAILURE_TYPE_2="" \
+  LLM_D_FAILURE_TYPE_3=""
+kubectl rollout status deployment/$PRIMARY_BACKEND -n $NAMESPACE
+
+echo ""
+read -p "✋ Ready to send baseline requests. Press ENTER to continue..."
+
+echo -e "\n${PURPLE}📡 BASELINE TEST REQUESTS (NO retry policy)${NC}"
+echo "-------------------------------------------"
+
+for i in {1..2}; do
+  echo -e "\n${CYAN}🔹 Baseline Request $i:${NC}"
+  echo "   Request: POST /v1/chat/completions"
+  echo "   Payload: {\"model\": \"$MODEL\", \"messages\": [{\"role\": \"user\", \"content\": \"Baseline test without retry policy\"}]}"
+  echo "   Expected: Fast failure (1-5 seconds)"
+  echo ""
+  
+  START_TIME=$(date +%s.%3N)
+  
+  RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}\nTIME_TOTAL:%{time_total}" -H "Content-Type: application/json" \
+    --max-time 45 \
+    -d "{
+      \"model\": \"$MODEL\",
+      \"messages\": [{\"role\": \"user\", \"content\": \"Baseline test without retry policy\"}]
+    }" \
+    http://localhost:$PORT_FORWARD/v1/chat/completions)
+  
+  END_TIME=$(date +%s.%3N)
+  TOTAL_TIME=$(echo "$END_TIME - $START_TIME" | bc -l)
+  
+  HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+  CURL_TIME=$(echo "$RESPONSE" | grep "TIME_TOTAL:" | cut -d: -f2)
+  BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d' | sed '/TIME_TOTAL:/d')
+  
+  echo -e "   ${BLUE}📊 Response Status:${NC} $HTTP_STATUS"
+  echo -e "   ${BLUE}⏱️  Response Time:${NC} ${TOTAL_TIME}s (curl: ${CURL_TIME}s)"
+  echo -e "   ${BLUE}📄 Response Body:${NC}"
+  echo "$BODY" | jq . 2>/dev/null || echo "$BODY" | head -c 200
+  
+  if [ "$HTTP_STATUS" = "200" ]; then
+    echo -e "   ${GREEN}✅ Request succeeded (unexpected without retry policy)${NC}"
+  else
+    echo -e "   ${RED}❌ Request failed as expected without retry policy - primary backend is down${NC}"
+  fi
+  
+  if [ $i -lt 2 ]; then
+    echo ""
+    read -p "   ⏸️  Press ENTER for next baseline request..."
+  fi
+done
+
+echo ""
+echo -e "${YELLOW}📋 PHASE 1 SUMMARY:${NC}"
+echo "• Without retry policy, requests fail quickly"
+echo "• Primary backend is returning server errors (HTTP 503)"
+echo "• No fallback mechanism is activated"
+echo "• Response times are fast (~1-5 seconds)"
+echo ""
+read -p "Press ENTER to proceed to Phase 2 (with retry policy)..."
+
+echo -e "\n${GREEN}🚀 PHASE 2: Testing WITH retry policy (retries and fallback)${NC}"
+echo "============================================================"
+
+# Apply retry policy
+echo -e "${YELLOW}🔧 Applying retry policy...${NC}"
+kubectl apply -f retry-policy.yaml
+sleep 5
+
+echo -e "${YELLOW}⏳ Waiting for retry policy to take effect...${NC}"
+sleep 5
+
+echo ""
+read -p "✋ Ready to send requests with retry policy. Press ENTER to continue..."
+
+echo -e "\n${PURPLE}📡 RETRY POLICY TEST REQUESTS${NC}"
+echo "------------------------------"
+echo -e "${CYAN}Retry Policy Configuration:${NC}"
+echo "• Max Retries: 5"
+echo "• Per-Retry Timeout: 30s"
+echo "• Backoff: 100ms-10s"
+echo "• Retry On: HTTP 503, connect failures"
+echo ""
+
+for i in {1..3}; do
+  echo -e "\n${CYAN}🔹 Retry Policy Request $i:${NC}"
+  echo "   Request: POST /v1/chat/completions"
+  echo "   Payload: {\"model\": \"$MODEL\", \"messages\": [{\"role\": \"user\", \"content\": \"Test with retry policy enabled\"}]}"
+  echo "   Expected: Longer duration, eventual success via fallback"
+  echo ""
+  
+  START_TIME=$(date +%s.%3N)
+  
+  RESPONSE=$(curl -s -w "\nHTTP_STATUS:%{http_code}\nTIME_TOTAL:%{time_total}" -H "Content-Type: application/json" \
+    --max-time 180 \
+    -d "{
+      \"model\": \"$MODEL\",
+      \"messages\": [{\"role\": \"user\", \"content\": \"Test with retry policy enabled\"}]
+    }" \
+    http://localhost:$PORT_FORWARD/v1/chat/completions)
+  
+  END_TIME=$(date +%s.%3N)
+  TOTAL_TIME=$(echo "$END_TIME - $START_TIME" | bc -l)
+  
+  HTTP_STATUS=$(echo "$RESPONSE" | grep "HTTP_STATUS:" | cut -d: -f2)
+  CURL_TIME=$(echo "$RESPONSE" | grep "TIME_TOTAL:" | cut -d: -f2)
+  BODY=$(echo "$RESPONSE" | sed '/HTTP_STATUS:/d' | sed '/TIME_TOTAL:/d')
+  
+  echo -e "   ${BLUE}📊 Response Status:${NC} $HTTP_STATUS"
+  echo -e "   ${BLUE}⏱️  Response Time:${NC} ${TOTAL_TIME}s (curl: ${CURL_TIME}s)"
+  echo -e "   ${BLUE}📄 Response Body:${NC}"
+  echo "$BODY" | jq . 2>/dev/null || echo "$BODY" | head -c 200
+  
+  if [ "$HTTP_STATUS" = "200" ]; then
+    echo -e "   ${GREEN}✅ FALLBACK SUCCESSFUL! Request completed despite primary failure${NC}"
+    
+    # Check which backend served the request
+    echo -e "   ${BLUE}🔍 Verifying backend source...${NC}"
+    FALLBACK_LOGS=$(kubectl logs -l app=$FALLBACK_BACKEND -n $NAMESPACE --tail=5 2>/dev/null | grep -E "(POST|GET|chat|completions)" | tail -1)
+    PRIMARY_LOGS=$(kubectl logs -l app=$PRIMARY_BACKEND -n $NAMESPACE --tail=5 2>/dev/null | grep -E "(POST|GET|chat|completions)" | tail -1)
+    
+    if [[ -n "$FALLBACK_LOGS" ]]; then
+      echo -e "   ${GREEN}✅ CONFIRMED: Request served by FALLBACK backend${NC}"
+    elif [[ -n "$PRIMARY_LOGS" ]]; then
+      echo -e "   ${YELLOW}⚠️  Request served by primary backend (unexpected)${NC}"
+    else
+      echo -e "   ${YELLOW}❓ Unable to determine backend source from logs${NC}"
+    fi
+  else
+    echo -e "   ${RED}❌ Request failed even with retry policy (Status: $HTTP_STATUS)${NC}"
+  fi
+  
+  if [ $i -lt 3 ]; then
+    echo ""
+    read -p "   ⏸️  Press ENTER for next retry policy request..."
+  fi
+done
+
+echo ""
+echo -e "${YELLOW}📋 PHASE 2 SUMMARY:${NC}"
+echo "• With retry policy, requests eventually succeed"
+echo "• Envoy retries failed requests to primary backend"
+echo "• After exhausting retries, traffic routes to fallback backend"
+echo "• Response times are longer due to retry attempts"
+echo "• Fallback backend responds successfully"
+echo ""
+read -p "Press ENTER to view detailed analysis..."
+
+echo -e "\n${CYAN}🔍 PHASE 3: Detailed Analysis and Evidence${NC}"
+echo "=========================================="
+
+echo -e "\n${PURPLE}📊 RETRY POLICY CONFIGURATION:${NC}"
+kubectl get backendtrafficpolicy retry-policy -n $NAMESPACE -o yaml 2>/dev/null | grep -A 10 "retry:" || echo "❌ Retry policy not found"
+
+echo -e "\n${PURPLE}📈 GATEWAY RETRY METRICS:${NC}"
+ENVOY_POD=$(kubectl get pods -n envoy-gateway-system --selector=gateway.envoyproxy.io/owning-gateway-name=$GATEWAY_NAME -o jsonpath='{.items[0].metadata.name}')
+
+# Port forward to admin interface for detailed metrics
+kubectl port-forward -n envoy-gateway-system $ENVOY_POD 19002:19000 &
+PF_PID=$!
+sleep 3
+
+echo "Collecting metrics from Envoy pod: $ENVOY_POD"
+STATS=$(curl -s localhost:19002/stats 2>/dev/null)
+
+echo -e "\n${BLUE}--- Primary Backend Stats ---${NC}"
+echo "$STATS" | grep -E "cluster\.backend/default/$PRIMARY_BACKEND.*\.(upstream_rq_total|upstream_rq_5xx|upstream_rq_timeout|upstream_rq_retry|upstream_rq_retry_success|upstream_cx_connect_fail):" | head -5
+
+echo -e "\n${BLUE}--- Fallback Backend Stats ---${NC}"
+echo "$STATS" | grep -E "cluster\.backend/default/$FALLBACK_BACKEND.*\.(upstream_rq_total|upstream_rq_2xx|upstream_rq_timeout):" | head -5
+
+echo -e "\n${BLUE}--- Retry-Specific Metrics ---${NC}"
+echo "$STATS" | grep -E "retry\.(upstream_rq_retry|upstream_rq_retry_success|upstream_rq_retry_overflow):" | head -5 || echo "No retry metrics found"
+
+kill $PF_PID 2>/dev/null || true
+
+echo -e "\n${CYAN}🕐 TIMEOUT COMPARISON RESULTS:${NC}"
+echo "=============================="
+echo -e "${RED}WITHOUT Retry Policy:${NC}"
+echo "• Fast failures (~1-5 seconds)"
+echo "• HTTP 503 server errors"
+echo "• No fallback activation"
+echo ""
+echo -e "${GREEN}WITH Retry Policy:${NC}"
+echo "• Longer response times (due to retries)"
+echo "• HTTP 200 success (via fallback)"
+echo "• Automatic failover to secondary backend"
+echo "• Retry attempts visible in metrics"
+
+echo ""
+echo -e "${YELLOW}🎯 KEY LEARNINGS:${NC}"
+echo "• Retry policies enable resilient AI gateway behavior"
+echo "• Fallback providers ensure service availability"
+echo "• Timeout configuration balances speed vs reliability"
+echo "• Metrics provide visibility into retry and failover behavior"
+
+echo ""
+read -p "Press ENTER to see recovery options..."
+
+echo -e "\n${CYAN}🔧 Recovery Options${NC}"
+echo "=================="
+echo "Primary backend is currently configured to fail."
+echo "Options:"
+echo "1. Keep primary failed for further testing"
+echo "2. Recover primary to healthy state"
+echo ""
+read -p "Do you want to recover the primary backend now? (y/N): " RECOVER
+if [[ "$RECOVER" == "y" || "$RECOVER" == "Y" ]]; then
+  echo -e "${YELLOW}Recovering primary backend...${NC}"
+  kubectl set env deployment/$PRIMARY_BACKEND -n $NAMESPACE \
+    LLM_D_MODE=random \
+    LLM_D_FAILURE_INJECTION_RATE=0 \
+    LLM_D_FAILURE_TYPE_1="" \
+    LLM_D_FAILURE_TYPE_2="" \
+    LLM_D_FAILURE_TYPE_3=""
+  kubectl rollout status deployment/$PRIMARY_BACKEND -n $NAMESPACE
+  echo -e "${GREEN}✅ Primary backend restored to healthy state${NC}"
+else
+  echo -e "${YELLOW}Primary backend remains in failed state.${NC}"
+  echo "Use 'task simulate-primary-recovery' to recover it later."
+fi
+
+echo ""
+echo -e "${GREEN}🎉 Timeout Analysis Demo Complete!${NC}"
+echo "=================================="
+echo "You have successfully observed the difference between:"
+echo "• Fast failures without retry policies"
+echo "• Resilient behavior with retry policies and fallback"
+echo ""
+echo "Next steps:"
+echo "• Run 'task show-retry-evidence' for detailed metrics"
+echo "• Try other failure modes with 'task test-all-failure-modes'"
+echo "• Explore circuit breaker behavior with 'task test-circuit-breaker'"


### PR DESCRIPTION
This pull request introduces a comprehensive demo for provider fallback in Envoy AI Gateway. It sets up both primary and fallback AI providers, configures automatic failover, retry, and circuit breaker policies, and provides documentation and Kubernetes manifests for easy deployment and testing. The changes are grouped into documentation, backend setup, routing configuration, and traffic policy.

**Documentation and Demo Instructions:**

* Added a detailed `README.md` describing the provider fallback demo, including setup steps, available tasks, architecture overview, configuration details, testing scenarios, monitoring, troubleshooting, and references.

**Backend Deployments and Services:**

* Added Kubernetes manifests for the primary (`llm-primary`) and fallback (`llm-fallback`) AI providers, including deployments, services, and backend configuration for each. The primary simulates unreliability, while the fallback is fast and reliable. [[1]](diffhunk://#diff-b141c2988baaa3275f93d7ac8b9f8085719cafff829f0b927edc79d13078171fR1-R123) [[2]](diffhunk://#diff-115458499b19f950b1a24c81bee124fd5690635b1f81e91bcb8f13da3010a0c8R1-R123)

**Routing and Gateway Configuration:**

* Added an `AIGatewayRoute` manifest to route requests for the `gpt-4` model, specifying both primary and fallback backends for automatic failover.

**Traffic Policy and Reliability:**

* Added a `BackendTrafficPolicy` manifest to configure retry behavior, including number of retries, backoff intervals, timeout, and retry triggers for handling provider failures.